### PR TITLE
Fix: Add start script in package.json to run backend server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
### Description
This PR fixes the issue #<issue-number> by adding a `start` script to the `package.json` file
in the `server` folder. Without this script, running `npm start` did not launch the backend server.

### Changes Made
- Added the following `start` script in `server/package.json`:

```json
"scripts": {
  "start": "node server.js"
}
```
closes #9 
