### PR TITLE
Add owner-only DELETE /api/expenses/:id

### DIFF
--- a/server/routes/expenseRoutes.js
+++ b/server/routes/expenseRoutes.js
@@ -86,4 +86,19 @@ router.put("/:id", protect, async (req, res) => {
   }
 });
 
+// @route   DELETE /api/expenses/:id
+// @desc    Delete an expense (owner only)
+router.delete('/:id', protect, async (req, res) => {
+  try {
+    const expense = await Expense.findOne({ _id: req.params.id, user: req.user._id });
+
+    if (!expense) return res.status(404).json({ message: 'Expense not found' });
+
+    await expense.remove();
+    res.json({ message: 'Expense deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Delete failed', error: err.message });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary

Implements a protected DELETE endpoint to remove an expense by id. The endpoint only allows the authenticated owner of the expense to delete it.

## Changes

- Added `DELETE /api/expenses/:id` to `server/routes/expenseRoutes.js`
- Looks up expense by id + user:
  ```js
  Expense.findOne({ _id: req.params.id, user: req.user._id })
  ```
- Returns `404` when not found / not owned
- Removes the expense and returns `200` with:
  ```json
  { "message": "Expense deleted" }
  ```